### PR TITLE
feat: Add ServerCheat meta property to allow cheats to run on server

### DIFF
--- a/MetaCheatManager.uplugin
+++ b/MetaCheatManager.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "mailto:janseliw@gmail.com",
-	"EngineVersion": "5.3.0",
+	"EngineVersion": "5.4",
 	"EnabledByDefault": true,
 	"CanContainContent": false,
 	"IsBetaVersion": false,

--- a/Source/MetaCheatManager/Private/MetaCheatCommand.cpp
+++ b/Source/MetaCheatManager/Private/MetaCheatCommand.cpp
@@ -37,6 +37,11 @@ FMetaCheatCommand FMetaCheatCommand::Create(const UFunction* InFunction)
 		return EmptyCommand;
 	}
 
+//++Ck
+    static const FName ServerCheatMetaKey = TEXT("ServerCheat");
+    CheatCommand.ExecuteOnServer = InFunction->HasMetaData(ServerCheatMetaKey);
+//--Ck
+
 	CheatCommand.FunctionName = InFunction->GetFName();
 	CheatCommand.CheatDescription = FindCheatDescription(InFunction);
 	return CheatCommand;

--- a/Source/MetaCheatManager/Public/MetaCheatCommand.h
+++ b/Source/MetaCheatManager/Public/MetaCheatCommand.h
@@ -30,6 +30,11 @@ struct METACHEATMANAGER_API FMetaCheatCommand
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	FName CheatDescription = NAME_None;
 
+//++Ck
+	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	bool ExecuteOnServer = false;
+//--Ck
+
 	/** Returns true if this command contains correct data */
 	FORCEINLINE bool IsValid() const
 	{

--- a/Source/MetaCheatManager/Public/MetaCheatManager.h
+++ b/Source/MetaCheatManager/Public/MetaCheatManager.h
@@ -56,6 +56,10 @@ public:
 	 * @see UMetaCheatManager::AllCheatCommands */
 	virtual const FORCEINLINE TArray<FMetaCheatCommand>& GetAllCheatCommands() const override { return AllCheatCommands; }
 
+//++Ck
+    virtual APlayerController* GetOuterPlayerController() const override { return GetOuterAPlayerController(); };
+//--Ck
+
 protected:
 	/** Contains all cheat commands exposed by this cheat manager.
 	 * Is automatically saved into config file while in editor to have these commands available in builds where is no access to meta data. */

--- a/Source/MetaCheatManager/Public/MetaCheatManagerExtension.h
+++ b/Source/MetaCheatManager/Public/MetaCheatManagerExtension.h
@@ -28,6 +28,10 @@ public:
 	 * @see UMetaCheatManager::AllCheatCommands */
 	virtual const FORCEINLINE TArray<FMetaCheatCommand>& GetAllCheatCommands() const override { return AllCheatCommands; }
 
+//++Ck
+    virtual APlayerController* GetOuterPlayerController() const override { return nullptr; };
+//--Ck
+
 protected:
 	/** Contains all cheat commands exposed by this cheat manager.
 	 * Is automatically saved into config file while in editor to have these commands available in builds where is no access to meta data. */

--- a/Source/MetaCheatManager/Public/MetaCheatManagerInterface.h
+++ b/Source/MetaCheatManager/Public/MetaCheatManagerInterface.h
@@ -29,6 +29,11 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "C++")
 	virtual const TArray<FMetaCheatCommand>& GetAllCheatCommands() const = 0;
 
+//++Ck
+	UFUNCTION(BlueprintCallable, Category = "C++")
+    virtual APlayerController* GetOuterPlayerController() const = 0;
+//--Ck
+
 	/** It has to be bound to UConsole::RegisterConsoleAutoCompleteEntries to register the cheat in the console. */
 	virtual void RegisterAutoCompleteEntries(TArray<struct FAutoCompleteCommand>& OutCommands) const = 0;
 };


### PR DESCRIPTION
*  Adding ServerCheat to a function's meta params will cause it to run on server
*  GetOuterPlayerController can get the controller of the player that originally called the command, even on server
*  Changed version number to not warn every time compiling